### PR TITLE
Clean up the Nix evaluator

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,7 @@
         {
           cicero = prev.callPackage pkgs/cicero {flake = self;};
           cicero-entrypoint = prev.callPackage pkgs/cicero/entrypoint.nix {};
-          cicero-evaluator-nix = prev.callPackage pkgs/cicero/evaluators/nix {flake = self;};
+          cicero-evaluator-nix = prev.callPackage pkgs/cicero/evaluators/nix {};
           webhook-trigger = prev.callPackage pkgs/trigger {};
           cicero-api = (final.extend haskell-nix.overlay).callPackage pkgs/cicero-api {
             inherit supportedSystems;

--- a/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
+++ b/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
@@ -34,11 +34,12 @@ eval)
 			--expr '{...}@args: args // {
 			  id = if args.id == "" then null else args.id;
 			  inputs = builtins.fromJSON args.inputs;
+			  attrs = __filter __isString (__split "[[:space:]]" args.attrs);
 			}' \
 			--argstr inputs "${CICERO_ACTION_INPUTS:-null}" \
 			--argstr name "${CICERO_ACTION_NAME:-}" \
 			--argstr id "${CICERO_ACTION_ID:-}" \
-			--arg attrs "[$(printf ' "%s"' "$@")]"
+			--argstr attrs "${*}"
 	)"
 
 	evaluate --apply "$(

--- a/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
+++ b/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
@@ -1,0 +1,67 @@
+# shellcheck shell=bash
+
+function usage {
+	{
+		echo "Usage: $(basename "$0") [list] [eval <attrs...>]"
+		echo
+		echo 'The following env vars must be set:'
+		echo -e '\t- CICERO_ACTION_SRC'
+		echo
+		echo 'For eval, the following env vars must be set:'
+		echo -e '\t- CICERO_ACTION_NAME'
+		echo -e '\t- CICERO_ACTION_ID'
+		echo -e '\t- CICERO_ACTION_INPUTS'
+		echo
+		echo 'The following env vars are optional:'
+		echo -e '\t- CICERO_EVALUATOR_NIX_STACKTRACE'
+	} >&2
+}
+
+function evaluate {
+	nix eval --no-write-lock-file --json \
+		${CICERO_EVALUATOR_NIX_STACKTRACE:+--show-trace} \
+		"${CICERO_ACTION_SRC:-.}#ciceroActions" "$@"
+}
+
+case "${1:-}" in
+list)
+	evaluate --apply builtins.attrNames
+	;;
+eval)
+	shift
+	vars="$(
+		nix-instantiate --eval --strict \
+			--expr '{...}@args: args // { inputs = builtins.fromJSON args.inputs; }' \
+			--argstr inputs "${CICERO_ACTION_INPUTS:-null}" \
+			--argstr name "${CICERO_ACTION_NAME:-none}" \
+			--argstr id "${CICERO_ACTION_ID:-null}" \
+			--arg attrs "[$(printf ' "%s"' "$@")]"
+	)"
+
+	evaluate --apply "$(
+		cat <<-EOF
+			actions:
+			let
+			  inherit (builtins) attrNames elem filter fromJSON isString listToAttrs split;
+			  inherit (${vars}) attrs id inputs name;
+			  action = actions."\${name}" { inherit id inputs; };
+			in
+			  builtins.listToAttrs (map
+			    (name: { inherit name; value = action."\${name}"; })
+			    (filter (name: elem name attrs) (attrNames action)))
+		EOF
+	)"
+	;;
+'')
+	echo >&2 'No command given'
+	echo >&2
+	usage
+	exit 1
+	;;
+*)
+	echo >&2 "Unknown command: $1"
+	echo >&2
+	usage
+	exit 1
+	;;
+esac

--- a/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
+++ b/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
@@ -48,13 +48,13 @@ eval)
 			  inherit (builtins) attrNames elem filter fromJSON isString listToAttrs split;
 			  inherit (${vars}) attrs id inputs name;
 			  nonNullAttr = k: v: if v == null then {} else { \${k} = v; };
-			  action = actions."\${name}" (
+			  action = actions.\${name} (
 			    nonNullAttr "id" id //
 			    nonNullAttr "inputs" inputs
 			  );
 			in
 			  builtins.listToAttrs (map
-			    (name: { inherit name; value = action."\${name}"; })
+			    (name: { inherit name; value = action.\${name}; })
 			    (filter (name: elem name attrs) (attrNames action)))
 		EOF
 	)"

--- a/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
+++ b/pkgs/cicero/evaluators/nix/cicero-evaluator-nix.sh
@@ -25,7 +25,7 @@ function evaluate {
 
 case "${1:-}" in
 list)
-	evaluate --apply builtins.attrNames
+	evaluate --apply __attrNames
 	;;
 eval)
 	shift
@@ -33,7 +33,7 @@ eval)
 		nix-instantiate --eval --strict \
 			--expr '{...}@args: args // {
 			  id = if args.id == "" then null else args.id;
-			  inputs = builtins.fromJSON args.inputs;
+			  inputs = __fromJSON args.inputs;
 			  attrs = __filter __isString (__split "[[:space:]]" args.attrs);
 			}' \
 			--argstr inputs "${CICERO_ACTION_INPUTS:-null}" \
@@ -46,7 +46,6 @@ eval)
 		cat <<-EOF
 			actions:
 			let
-			  inherit (builtins) attrNames elem filter fromJSON isString listToAttrs split;
 			  inherit (${vars}) attrs id inputs name;
 			  nonNullAttr = k: v: if v == null then {} else { \${k} = v; };
 			  action = actions.\${name} (
@@ -54,9 +53,9 @@ eval)
 			    nonNullAttr "inputs" inputs
 			  );
 			in
-			  builtins.listToAttrs (map
+			  __listToAttrs (map
 			    (name: { inherit name; value = action.\${name}; })
-			    (filter (name: elem name attrs) (attrNames action)))
+			    (__filter (name: __elem name attrs) (__attrNames action)))
 		EOF
 	)"
 	;;

--- a/pkgs/cicero/evaluators/nix/default.nix
+++ b/pkgs/cicero/evaluators/nix/default.nix
@@ -1,84 +1,10 @@
 {
-  flake,
-  writers,
+  writeShellApplication,
   coreutils,
+  lib,
 }:
-writers.writeBashBin "cicero-evaluator-nix" ''
-  PATH="$PATH:"${coreutils}/bin
-
-  function usage {
-      {
-          echo    "Usage: $(basename "$0") [list] [eval <attrs...>]"
-          echo
-          echo    'The following env vars must be set:'
-          echo -e '\t- CICERO_ACTION_SRC'
-          echo
-          echo    'For eval, the following env vars must be set:'
-          echo -e '\t- CICERO_ACTION_NAME'
-          echo -e '\t- CICERO_ACTION_ID'
-          echo -e '\t- CICERO_ACTION_INPUTS'
-          echo
-          echo    'The following env vars are optional:'
-          echo -e '\t- CICERO_EVALUATOR_NIX_STACKTRACE'
-      } >&2
-  }
-
-  function evaluate {
-      nix eval --no-write-lock-file --json \
-        ''${CICERO_EVALUATOR_NIX_STACKTRACE:+--show-trace} \
-        "$CICERO_ACTION_SRC"#ciceroActions "$@"
-  }
-
-  case "''${1:-}" in
-    list )
-        evaluate --apply builtins.attrNames
-        ;;
-    eval )
-        # XXX get rid of --impure
-        shift
-        attrs="$@" \
-        evaluate --impure --apply '
-          actions:
-
-          let
-            inherit (builtins)
-              getEnv fromJSON filter isString split attrNames elem;
-
-            action = let
-              ifEmptyThenNullElse = str: v: if str == "" then null else v;
-              id = getEnv "CICERO_ACTION_ID";
-              inputs = getEnv "CICERO_ACTION_INPUTS";
-            in actions.''${getEnv "CICERO_ACTION_NAME"} {
-              ''${ifEmptyThenNullElse id "id"} = id;
-              ''${ifEmptyThenNullElse inputs "inputs"} = fromJSON inputs;
-            };
-
-            attrs = filter isString (split "[[:space:]]+" (getEnv "attrs"));
-          in
-
-          builtins.listToAttrs (map
-            (name: {
-              inherit name;
-              value = action.''${name};
-            })
-            (filter
-              (name: elem name attrs)
-              (attrNames action)
-            )
-          )
-        '
-        ;;
-    ''' )
-        >&2 echo 'No command given'
-        >&2 echo
-        usage
-        exit 1
-        ;;
-    * )
-        >&2 echo "Unknown command: $1"
-        >&2 echo
-        usage
-        exit 1
-        ;;
-  esac
-''
+writeShellApplication {
+  name = "cicero-evaluator-nix";
+  runtimeInputs = [coreutils];
+  text = lib.fileContents ./cicero-evaluator-nix.sh;
+}


### PR DESCRIPTION
This now first transforms the environment variables to an attrset using
`nix-instantiate`, and then passes it to `nix eval`. This allows for use
of the evaluation cache and IMHO cleaner code.
The script is now also in its own file so we don't have to worry about
two stages of interpolation and get instant shellcheck feedback.
Also fixed a few shellcheck issues and use the awesome
`writeShellApplication`.