### PR TITLE
fix: error on vm-bigdisk flake configs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -172,7 +172,7 @@
           modules = [
             nixos/configs/vm.nix
             nixos-shell.nixosModules.nixos-shell
-            ({lib, ...}: {virtualisation.diskSize = lib.mkForce 1024 * 60;})
+            ({lib, ...}: {virtualisation.diskSize = lib.mkForce (1024 * 60);})
           ];
         };
 


### PR DESCRIPTION
A fix for the bellow error when I run `nix develop --command nixos-shell --flake .#vm-bigdisk`

```
error: value is a set while an integer was expected

       at /nix/store/w3v5jwygrqwifrj1s85gngikivdpq7yf-source/flake.nix:175:53:

          174|             nixos-shell.nixosModules.nixos-shell
          175|             ({lib, ...}: {virtualisation.diskSize = lib.mkForce 1024 * 60;})
             |                                                     ^
          176|           ];
```